### PR TITLE
53: Catch username taken error

### DIFF
--- a/stories/src/app/pages/signup/page.tsx
+++ b/stories/src/app/pages/signup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { ErrorCode } from "@/app/utils/errorCodes";
 
 export default function SignUp() {
 
@@ -26,12 +27,21 @@ export default function SignUp() {
                 Password: formElements.passwordInput.value,
             }),
         })
-        .then(response => {
+        .then(async response => {
             if (response.ok) {
                 router.push('/');
             }
             else {
-                setErrorMessage("You are being problematic :/ Please try again later.")
+                await response.json().then(error => {
+                    if (error.message == ErrorCode.UsernameTaken)
+                    {
+                        setErrorMessage("This username has already been taken. Please choose another.")
+                    }
+                    else 
+                    {
+                        setErrorMessage("You are being problematic :/ Please try again later.")
+                    }
+                });
             }
         })
         .catch(e => {

--- a/stories/src/app/utils/errorCodes.ts
+++ b/stories/src/app/utils/errorCodes.ts
@@ -1,0 +1,3 @@
+export enum ErrorCode {
+    UsernameTaken = "UsernameTaken"
+}


### PR DESCRIPTION
Checks the signup response for the custom UsernameTaken error. If this is the error message that gets returned, it sets the error message to be specific to the username being taken. If this is not the error message, it still uses the generic error message.

<img width="605" height="209" alt="Screenshot 2025-07-21 at 18 33 17" src="https://github.com/user-attachments/assets/d57c17f8-516d-4746-80e6-a6ac909aa2e0" />