### PR TITLE
47: Display usernames for posts

### DIFF
--- a/stories/src/app/components/DisplayStory.tsx
+++ b/stories/src/app/components/DisplayStory.tsx
@@ -19,12 +19,37 @@ export default function DisplayStory(props: Props) {
     
     useEffect(() => {
         const getPosts = async () => {
-            await fetch(`https://localhost:7009/api/Stories/${props.storyId}/Posts`)
+            // get posts
+            let posts = await fetch(`https://localhost:7009/api/Stories/${props.storyId}/Posts`)
             .then((response) => response.json())
             .then(data => {
-            setPosts(data);
+                return data;
             })
             .catch(error => console.log(error));
+
+            // get authors
+            let ids = posts.map((post: Post) => post.userId)
+            let authors = await fetch("https://localhost:7009/api/Users/multiget", {
+                method: "POST",
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    ids: ids
+                }),
+            })
+            .then(response => response.json())
+            .then(data => {
+                return data.users;
+            })
+            .catch(e => {console.log(e)});
+
+            // map authors to posts
+            for (let post of posts) {
+                post.author = authors[post.userId].username
+            }
+
+            setPosts(posts);
         }
         getPosts();
       }, [numPosts]);

--- a/stories/src/app/components/DisplayStory.tsx
+++ b/stories/src/app/components/DisplayStory.tsx
@@ -46,7 +46,7 @@ export default function DisplayStory(props: Props) {
 
             // map authors to posts
             for (let post of posts) {
-                post.author = authors[post.userId].username
+                post.authorName = authors[post.userId].username
             }
 
             setPosts(posts);
@@ -148,7 +148,7 @@ export default function DisplayStory(props: Props) {
                 {posts && posts.map((item) => (
                     <StoryPost
                         content={item.content}
-                        author={item.author}
+                        author={item.authorName}
                         date={new Date(item.date)}
                         key={item.postId}
                     />

--- a/stories/src/app/models/Post.ts
+++ b/stories/src/app/models/Post.ts
@@ -1,5 +1,6 @@
 export type Post = {
-    author: string; // 45 character max
+    userId: number; // 45 character max
+    authorName: string;
     content: string; // 10,000 character max
     date: Date;
     postId: number;

--- a/stories/src/app/pages/story/page.tsx
+++ b/stories/src/app/pages/story/page.tsx
@@ -23,8 +23,6 @@ export default function StoryPage() {
     getStory();
   }, []);
 
-
-
   return (
     <div className="grid items-start justify-items-center min-h-screen p-8 pb-20 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="grid items-center sm:items-start">

--- a/stories/src/app/pages/story/page.tsx
+++ b/stories/src/app/pages/story/page.tsx
@@ -23,6 +23,8 @@ export default function StoryPage() {
     getStory();
   }, []);
 
+
+
   return (
     <div className="grid items-start justify-items-center min-h-screen p-8 pb-20 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="grid items-center sm:items-start">


### PR DESCRIPTION
Uses new endpoint to get all of the usernames given a set of user ids. Displays these usernames above the posts.

<img width="945" height="414" alt="Screenshot 2025-08-31 at 14 22 02" src="https://github.com/user-attachments/assets/c684ae9b-b638-4745-8533-a87ff754504f" />
